### PR TITLE
Change generate arguments to an options hash

### DIFF
--- a/lib/madgab.rb
+++ b/lib/madgab.rb
@@ -8,7 +8,10 @@ module Madgab
 
   class << self
     # Generates a more random string of words like in the game Mad Gab
-    def generate(string_together=DEFAULT_STRING, join_with=DEFAULT_JOIN)
+    def generate(options = {})
+      string_together = options[:string_together] || DEFAULT_STRING
+      join_with = options[:default_string] || DEFAULT_JOIN
+
       unless defined? @@diction
         self.diction
       end


### PR DESCRIPTION
So that if you want to just change `join_with` you can do

``` ruby
Madgab.generate join_with: ' '
```

instead of having to provide the `string_together` argument too

``` ruby
Madgab.generate ["the", :adv, :adj, :noun, :verb], ' '
```
